### PR TITLE
fix runtime tests

### DIFF
--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use std::path::Path;
+use ocelotter_util::file_to_bytes;
 
 #[test]
 fn test_klass_name_from_fq() {


### PR DESCRIPTION
add 'use' for file_to_bytes to runtime/tests.rs. runtime tests pass now.